### PR TITLE
fix: add meridiem indicator to the 12-hour time format

### DIFF
--- a/.github/actions/python-test/action.yml
+++ b/.github/actions/python-test/action.yml
@@ -33,13 +33,13 @@ runs:
         docker compose -f docker/docker-compose.test.yml run test
     - name: Upload Coverage Data
       if: inputs.upload-coverage
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
       with:
         name: coverage-data
         path: report/coverage/.coverage
     - name: Publish Coverage Report
       if: inputs.upload-test-report
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
       with:
         name: coverage-report
         path: report/htmlcov

--- a/src/web/templates/web/events/event_detail.html
+++ b/src/web/templates/web/events/event_detail.html
@@ -232,11 +232,11 @@
 
             switch (netPrecisionID) {
                 case 0:
-                    return momentTZ.format("MMMM DD, YYYY - h:mm:ss z")
+                    return momentTZ.format("MMMM DD, YYYY - h:mm:ss A z")
                 case 1:
-                    return momentTZ.format("MMMM DD, YYYY - h:mm z")
+                    return momentTZ.format("MMMM DD, YYYY - h:mm A z")
                 case 2:
-                    return momentTZ.format("MMMM DD, YYYY - [NET] h:00 z")
+                    return momentTZ.format("MMMM DD, YYYY - [NET] h:00 A z")
                 case 3:
                     return momentVar.format("[Morning (local)] MMMM DD, YYYY")
                 case 4:

--- a/src/web/templates/web/launches/launch_detail_page.html
+++ b/src/web/templates/web/launches/launch_detail_page.html
@@ -902,11 +902,11 @@
 
             switch (netPrecisionID) {
                 case 0:
-                    return momentTZ.format("MMMM DD, YYYY - h:mm:ss z")
+                    return momentTZ.format("MMMM DD, YYYY - h:mm:ss A z")
                 case 1:
-                    return momentTZ.format("MMMM DD, YYYY - h:mm z")
+                    return momentTZ.format("MMMM DD, YYYY - h:mm A z")
                 case 2:
-                    return momentTZ.format("MMMM DD, YYYY - [NET] h:00 z")
+                    return momentTZ.format("MMMM DD, YYYY - [NET] h:00 A z")
                 case 3:
                     return momentVar.format("[Morning (local)] MMMM DD, YYYY")
                 case 4:

--- a/src/web/templates/web/launches/launch_detail_page_mobile.html
+++ b/src/web/templates/web/launches/launch_detail_page_mobile.html
@@ -857,11 +857,11 @@
 
             switch (netPrecisionID) {
                 case 0:
-                    return momentTZ.format("MMMM DD, YYYY - h:mm:ss z")
+                    return momentTZ.format("MMMM DD, YYYY - h:mm:ss A z")
                 case 1:
-                    return momentTZ.format("MMMM DD, YYYY - h:mm z")
+                    return momentTZ.format("MMMM DD, YYYY - h:mm A z")
                 case 2:
-                    return momentTZ.format("MMMM DD, YYYY - [NET] h:00 z")
+                    return momentTZ.format("MMMM DD, YYYY - [NET] h:00 A z")
                 case 3:
                     return momentVar.format("[Morning (local)] MMMM DD, YYYY")
                 case 4:


### PR DESCRIPTION
Hello!

I'm not sure if the launch time "11:30" of [Starship | Flight 8](https://spacelaunchnow.me/launch/starship-flight-8/) is before or after noon at first glance, so I've made this PR. Or we need to replace "h" with "H" to use 24-hour time format.

I don't have a local dev environment but have tested the JS code in web browsers. I referred to this docs: [Format § Moment.js | Docs](https://momentjs.com/docs/#/displaying/format/).